### PR TITLE
fix: Update GoalsWithtask filtering in Focus page and goal creation logic

### DIFF
--- a/src/components/focus/focus.tsx
+++ b/src/components/focus/focus.tsx
@@ -270,7 +270,7 @@ const Focus: React.FC = () => {
 
     // Filter goals that have tasks in focus
     const goalsWithTasksInFocus = goals.filter(goal => 
-        goal.tasks.some(task => task.isInFocus)
+        goal.tasks.some(task => task.isInFocus && !task.goalId)
     );
 
     const dropDownActions = [

--- a/src/lib/reducers.ts
+++ b/src/lib/reducers.ts
@@ -39,7 +39,7 @@ export function planTaskReducer(state: TaskState, action: TaskAction) {
                 goalId: action.goalId || null, // Use provided goalId or null
                 completed: false,
                 completedAt: null, // Add the completedAt property
-                isInFocus: action.taskId ? true : false,
+                isInFocus: false, // Default to false for new tasks
             }
             
             // If this task belongs to a goal, don't add it to the main tasks array
@@ -100,9 +100,11 @@ export function goalReducer(state: GoalState, action: GoalAction) {
         }
 
         case 'added': {
+            // Generate a unique number ID using crypto.randomUUID()
+            const goalId = parseInt(crypto.randomUUID().replace(/-/g, '').slice(0, 8), 16);
             const newGoal: GoalWithTasks = {
                 ...action.values,
-                id: Date.now(),
+                id: goalId,
                 description: null,
                 createdAt: new Date(),
                 updatedAt: new Date(),
@@ -110,11 +112,11 @@ export function goalReducer(state: GoalState, action: GoalAction) {
                 endDate: new Date(),
                 frequency: null,
                 userId: nanoid(),
-                bestTimeTitle: action.values.bestTimeTitle ?? null, // Ensure null is used
+                bestTimeTitle: action.values.bestTimeTitle ?? null,
                 bestTimeDescription: action.values.bestTimeDescription ?? null,
                 tasks: [
                     {
-                        id: Date.now(),
+                        id: parseInt(crypto.randomUUID().replace(/-/g, '').slice(0, 8), 16),
                         title: 'Your Goal Here',
                         difficulty: null,
                         description: null,
@@ -123,12 +125,12 @@ export function goalReducer(state: GoalState, action: GoalAction) {
                         frequency: 'Once',
                         duration: '5 mins',
                         userId: nanoid(),
-                        goalId: null,
+                        goalId: goalId,
                         completed: false,
                         completedAt: null,
                         isInFocus: false
                     }
-                ], // Add an empty tasks array to conform to GoalWithTasks
+                ],
             }
             const nextGoal = [...state, newGoal]
             saveGoalsToLocal(nextGoal)


### PR DESCRIPTION
- Modified the task filtering to exclude tasks with a goalId when determining tasks in focus.
- Updated goal creation to use a unique ID generated by crypto.randomUUID() for both goals and their initial tasks, ensuring better uniqueness and consistency.
